### PR TITLE
修改service.ftl中已经被废弃的变量名

### DIFF
--- a/src/main/java/com/thinkgem/jeesite/generate/template/service.ftl
+++ b/src/main/java/com/thinkgem/jeesite/generate/template/service.ftl
@@ -37,7 +37,7 @@ public class ${ClassName}Service extends BaseService {
 		if (StringUtils.isNotEmpty(${className}.getName())){
 			dc.add(Restrictions.like("name", "%"+${className}.getName()+"%"));
 		}
-		dc.add(Restrictions.eq(${ClassName}.DEL_FLAG, ${ClassName}.DEL_FLAG_NORMAL));
+		dc.add(Restrictions.eq(${ClassName}.FIELD_DEL_FLAG, ${ClassName}.DEL_FLAG_NORMAL));
 		dc.addOrder(Order.desc("id"));
 		return ${className}Dao.find(page, dc);
 	}


### PR DESCRIPTION
service中DEL_FLAG已经在前几次的fix中取消，因此需要替换
