### PR TITLE
Update frontGuestbook.jsp

### DIFF
--- a/src/main/webapp/WEB-INF/views/modules/cms/front/themes/basic/frontGuestbook.jsp
+++ b/src/main/webapp/WEB-INF/views/modules/cms/front/themes/basic/frontGuestbook.jsp
@@ -57,7 +57,7 @@
 		</ul>
 		<div class="pagination">${page}</div>
 		<h4>我要留言</h4>
-		<form:form id="inputForm" action="" method="post" class="form-horizontal">
+		<form:form id="inputForm" action="${ctx}/guestbook" method="post" class="form-horizontal">
 			<div class="control-group">
 				<label class="control-label">名称:</label>
 				<div class="controls">


### PR DESCRIPTION
问题：连续提交两次留言报错
分析：Guestbook中包含type属性，在第一次提交后，重定向的路径中含有type参数，再次提交时会将type属性拼接，如“3,4”导致系统错误