### PR TITLE
完善mvn初始化数据库功能对mysql的支持：

### DIFF
--- a/db/cms/jeesite_mysql.sql
+++ b/db/cms/jeesite_mysql.sql
@@ -2,13 +2,13 @@ SET SESSION FOREIGN_KEY_CHECKS=0;
 
 /* Drop Tables */
 
-DROP TABLE cms_article_data;
-DROP TABLE cms_article;
-DROP TABLE cms_comment;
-DROP TABLE cms_link;
-DROP TABLE cms_category;
-DROP TABLE cms_guestbook;
-DROP TABLE cms_site;
+DROP TABLE IF EXISTS cms_article_data;
+DROP TABLE IF EXISTS cms_article;
+DROP TABLE IF EXISTS cms_comment;
+DROP TABLE IF EXISTS cms_link;
+DROP TABLE IF EXISTS cms_category;
+DROP TABLE IF EXISTS cms_guestbook;
+DROP TABLE IF EXISTS cms_site;
 
 
 
@@ -174,7 +174,6 @@ CREATE INDEX cms_article_weight ON cms_article (weight ASC);
 CREATE INDEX cms_article_update_date ON cms_article (update_date ASC);
 CREATE INDEX cms_article_category_id ON cms_article (category_id ASC);
 CREATE INDEX cms_category_parent_id ON cms_category (parent_id ASC);
-CREATE INDEX cms_category_parent_ids ON cms_category (parent_ids ASC);
 CREATE INDEX cms_category_module ON cms_category (module ASC);
 CREATE INDEX cms_category_name ON cms_category (name ASC);
 CREATE INDEX cms_category_sort ON cms_category (sort ASC);

--- a/db/gen/jeesite_mysql.sql
+++ b/db/gen/jeesite_mysql.sql
@@ -2,10 +2,10 @@ SET SESSION FOREIGN_KEY_CHECKS=0;
 
 /* Drop Tables */
 
-DROP TABLE gen_scheme;
-DROP TABLE gen_table_column;
-DROP TABLE gen_table;
-DROP TABLE gen_template;
+DROP TABLE IF EXISTS gen_scheme;
+DROP TABLE IF EXISTS gen_table_column;
+DROP TABLE IF EXISTS gen_table;
+DROP TABLE IF EXISTS gen_template;
 
 
 

--- a/db/oa/jeesite_mysql.sql
+++ b/db/oa/jeesite_mysql.sql
@@ -2,10 +2,10 @@ SET SESSION FOREIGN_KEY_CHECKS=0;
 
 /* Drop Tables */
 
-DROP TABLE oa_leave;
-DROP TABLE oa_notify_record;
-DROP TABLE oa_notify;
-DROP TABLE OA_TEST_AUDIT;
+DROP TABLE IF EXISTS oa_leave;
+DROP TABLE IF EXISTS oa_notify_record;
+DROP TABLE IF EXISTS oa_notify;
+DROP TABLE IF EXISTS OA_TEST_AUDIT;
 
 
 

--- a/db/sys/jeesite_mysql.sql
+++ b/db/sys/jeesite_mysql.sql
@@ -2,17 +2,17 @@ SET SESSION FOREIGN_KEY_CHECKS=0;
 
 /* Drop Tables */
 
-DROP TABLE sys_role_office;
-DROP TABLE sys_user_role;
-DROP TABLE sys_user;
-DROP TABLE sys_office;
-DROP TABLE sys_area;
-DROP TABLE sys_dict;
-DROP TABLE sys_log;
-DROP TABLE sys_mdict;
-DROP TABLE sys_role_menu;
-DROP TABLE sys_menu;
-DROP TABLE sys_role;
+DROP TABLE IF EXISTS sys_role_office ;
+DROP TABLE IF EXISTS sys_user_role;
+DROP TABLE IF EXISTS sys_user;
+DROP TABLE IF EXISTS sys_office;
+DROP TABLE IF EXISTS sys_area;
+DROP TABLE IF EXISTS sys_dict;
+DROP TABLE IF EXISTS sys_log;
+DROP TABLE IF EXISTS sys_mdict;
+DROP TABLE IF EXISTS sys_role_menu;
+DROP TABLE IF EXISTS sys_menu;
+DROP TABLE IF EXISTS sys_role;
 
 
 
@@ -59,7 +59,7 @@ CREATE TABLE sys_dict
 
 CREATE TABLE sys_log
 (
-	id varchar(64) NOT NULL AUTO_INCREMENT COMMENT '编号',
+	id varchar(64) NOT NULL COMMENT '编号',
 	type char(1) DEFAULT '1' COMMENT '日志类型',
 	title varchar(255) DEFAULT '' COMMENT '日志标题',
 	create_by varchar(64) COMMENT '创建者',
@@ -219,7 +219,6 @@ CREATE TABLE sys_user_role
 /* Create Indexes */
 
 CREATE INDEX sys_area_parent_id ON sys_area (parent_id ASC);
-CREATE INDEX sys_area_parent_ids ON sys_area (parent_ids ASC);
 CREATE INDEX sys_area_del_flag ON sys_area (del_flag ASC);
 CREATE INDEX sys_dict_value ON sys_dict (value ASC);
 CREATE INDEX sys_dict_label ON sys_dict (label ASC);
@@ -229,13 +228,10 @@ CREATE INDEX sys_log_request_uri ON sys_log (request_uri ASC);
 CREATE INDEX sys_log_type ON sys_log (type ASC);
 CREATE INDEX sys_log_create_date ON sys_log (create_date ASC);
 CREATE INDEX sys_mdict_parent_id ON sys_mdict (parent_id ASC);
-CREATE INDEX sys_mdict_parent_ids ON sys_mdict (parent_ids ASC);
 CREATE INDEX sys_mdict_del_flag ON sys_mdict (del_flag ASC);
 CREATE INDEX sys_menu_parent_id ON sys_menu (parent_id ASC);
-CREATE INDEX sys_menu_parent_ids ON sys_menu (parent_ids ASC);
 CREATE INDEX sys_menu_del_flag ON sys_menu (del_flag ASC);
 CREATE INDEX sys_office_parent_id ON sys_office (parent_id ASC);
-CREATE INDEX sys_office_parent_ids ON sys_office (parent_ids ASC);
 CREATE INDEX sys_office_del_flag ON sys_office (del_flag ASC);
 CREATE INDEX sys_office_type ON sys_office (type ASC);
 CREATE INDEX sys_role_del_flag ON sys_role (del_flag ASC);

--- a/db/test/jeesite_mysql.sql
+++ b/db/test/jeesite_mysql.sql
@@ -2,10 +2,10 @@ SET SESSION FOREIGN_KEY_CHECKS=0;
 
 /* Drop Tables */
 
-DROP TABLE test_data;
-DROP TABLE test_data_child;
-DROP TABLE test_data_main;
-DROP TABLE test_tree;
+DROP TABLE IF EXISTS test_data;
+DROP TABLE IF EXISTS test_data_child;
+DROP TABLE IF EXISTS test_data_main;
+DROP TABLE IF EXISTS test_tree;
 
 
 
@@ -90,7 +90,6 @@ CREATE INDEX test_data_child_del_flag ON test_data_child (del_flag ASC);
 CREATE INDEX test_data_main_del_flag ON test_data_main (del_flag ASC);
 CREATE INDEX test_tree_del_flag ON test_tree (del_flag ASC);
 CREATE INDEX test_data_parent_id ON test_tree (parent_id ASC);
-CREATE INDEX test_data_parent_ids ON test_tree (parent_ids ASC);
 
 
 


### PR DESCRIPTION
1、添加“IF EXISTS”自动判断表是否存在。
2、mysql不支持主键为varchar时设置自增长，删除之。
3、mysql中作为索引的varchar类型字段长度不能长于255，删除无效索引。