### PR TITLE
修正以管理员身份运行时，CMD中路径不对的问题

### DIFF
--- a/bin/eclipse.bat
+++ b/bin/eclipse.bat
@@ -10,7 +10,7 @@ echo.
 pause
 echo.
 
-cd %~dp0
+cd /d %~dp0
 cd..
 
 call mvn -Declipse.workspace=%cd% eclipse:clean eclipse:eclipse


### PR DESCRIPTION
修正以管理员身份运行时，路径定位于C:\Windows\System32下的问题。