### PR TITLE
修复上传文件路径错误以及反射代理模式下登陆IP错误

### DIFF
--- a/src/main/java/com/thinkgem/jeesite/common/utils/FileUtils.java
+++ b/src/main/java/com/thinkgem/jeesite/common/utils/FileUtils.java
@@ -611,7 +611,7 @@ public class FileUtils extends org.apache.commons.io.FileUtils {
 		String p = StringUtils.replace(path, "\\", "/");
 		p = StringUtils.join(StringUtils.split(p, "/"), "/");
 		if (!StringUtils.startsWithAny(p, "/") && StringUtils.startsWithAny(path, "\\", "/")){
-			p += "/";
+			p = "/" + p;
 		}
 		if (!StringUtils.endsWithAny(p, "/") && StringUtils.endsWithAny(path, "\\", "/")){
 			p = p + "/";

--- a/src/main/java/com/thinkgem/jeesite/modules/sys/security/SystemAuthorizingRealm.java
+++ b/src/main/java/com/thinkgem/jeesite/modules/sys/security/SystemAuthorizingRealm.java
@@ -9,7 +9,6 @@ import java.util.List;
 
 import javax.annotation.PostConstruct;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.shiro.authc.AuthenticationException;
 import org.apache.shiro.authc.AuthenticationInfo;
 import org.apache.shiro.authc.AuthenticationToken;
@@ -29,6 +28,7 @@ import org.springframework.stereotype.Service;
 import com.thinkgem.jeesite.common.config.Global;
 import com.thinkgem.jeesite.common.servlet.ValidateCodeServlet;
 import com.thinkgem.jeesite.common.utils.Encodes;
+import com.thinkgem.jeesite.common.utils.StringUtils;
 import com.thinkgem.jeesite.common.utils.SpringContextHolder;
 import com.thinkgem.jeesite.common.web.Servlets;
 import com.thinkgem.jeesite.modules.sys.entity.Menu;
@@ -129,7 +129,8 @@ public class SystemAuthorizingRealm extends AuthorizingRealm {
 				info.addRole(role.getEnname());
 			}
 			// 更新登录IP和时间
-			getSystemService().updateUserLoginInfo(user);
+			String loginIP = StringUtils.getRemoteAddr(Servlets.getRequest());
+			getSystemService().updateUserLoginInfo(user, loginIP);
 			// 记录登录日志
 			LogUtils.saveLog(Servlets.getRequest(), "系统登录");
 			return info;

--- a/src/main/java/com/thinkgem/jeesite/modules/sys/service/SystemService.java
+++ b/src/main/java/com/thinkgem/jeesite/modules/sys/service/SystemService.java
@@ -192,12 +192,12 @@ public class SystemService extends BaseService implements InitializingBean {
 	}
 	
 	@Transactional(readOnly = false)
-	public void updateUserLoginInfo(User user) {
+	public void updateUserLoginInfo(User user, String loginIP) {
 		// 保存上次登录信息
 		user.setOldLoginIp(user.getLoginIp());
 		user.setOldLoginDate(user.getLoginDate());
 		// 更新本次登录信息
-		user.setLoginIp(UserUtils.getSession().getHost());
+		user.setLoginIp(loginIP);
 		user.setLoginDate(new Date());
 		userDao.updateLoginInfo(user);
 	}


### PR DESCRIPTION
1、修复在Linux环境下，上传文件路径错误问题，涉及类：FileUtils；
2、由于在反射代理模式下，shiro中gethost取的是127的地址，故改为取请求的ip地址，涉及类：SystemAuthorizingRealm，SystemService