### PR TITLE
解决pom找不到UserAgentUtils等依赖报错问题

### DIFF
--- a/bin/updateJeesitedependcy.txt
+++ b/bin/updateJeesitedependcy.txt
@@ -1,0 +1,11 @@
+mvn install:install-file -Dfile=D:\mvn\analyzer-2012_u6.jar -DgroupId=org.wltea -DartifactId=analyzer -Dversion=2012_u6 -Dpackaging=jar
+
+mvn install:install-file -Dfile=D:\mvn\apache-ant-zip-2.3.jar -DgroupId=com.ckfinder -DartifactId=apache-ant-zip -Dversion=2.3 -Dpackaging=jar
+
+mvn install:install-file -Dfile=D:\mvn\ckfinder-2.3.jar -DgroupId=com.ckfinder -DartifactId=ckfinder -Dversion=2.3 -Dpackaging=jar
+
+mvn install:install-file -Dfile=D:\mvn\ckfinderplugin-fileeditor-2.3.jar -DgroupId=com.ckfinder -DartifactId=ckfinderplugin-fileeditor -Dversion=2.3 -Dpackaging=jar
+
+mvn install:install-file -Dfile=D:\mvn\ckfinderplugin-imageresize-2.3.jar -DgroupId=com.ckfinder -DartifactId=ckfinderplugin-imageresize -Dversion=2.3 -Dpackaging=jar
+
+mvn install:install-file -Dfile=D:\mvn\UserAgentUtils-1.13.jar -DgroupId=bitwalker -DartifactId=UserAgentUtils -Dversion=1.13 -Dpackaging=jar


### PR DESCRIPTION
解决pom找不到UserAgentUtils等依赖--
安装UserAgentUtils等jar文件到maven本地仓库，以便解决找不到依赖的问题