### PR TITLE
修改防止log时内存泄漏

### DIFF
--- a/src/main/java/com/thinkgem/jeesite/modules/sys/interceptor/LogInterceptor.java
+++ b/src/main/java/com/thinkgem/jeesite/modules/sys/interceptor/LogInterceptor.java
@@ -61,6 +61,8 @@ public class LogInterceptor extends BaseService implements HandlerInterceptor {
 	        		new SimpleDateFormat("hh:mm:ss.SSS").format(endTime), DateUtils.formatDateTime(endTime - beginTime),
 					request.getRequestURI(), Runtime.getRuntime().maxMemory()/1024/1024, Runtime.getRuntime().totalMemory()/1024/1024, Runtime.getRuntime().freeMemory()/1024/1024, 
 					(Runtime.getRuntime().maxMemory()-Runtime.getRuntime().totalMemory()+Runtime.getRuntime().freeMemory())/1024/1024); 
+	        //删除线程变量中的数据，防止内存泄漏
+	        startTimeThreadLocal.remove();
 		}
 		
 	}


### PR DESCRIPTION
当日志处在debug模式时ThreadLocal 会原来越大，不释放内存，所以添加删除开始记录的时间防止内存泄漏
