### PR TITLE
[问题现象]添加通知的时候抛异常；[问题原因]相应的mapper文件里有误

### DIFF
--- a/src/main/resources/mappings/modules/oa/OaNotifyRecordDao.xml
+++ b/src/main/resources/mappings/modules/oa/OaNotifyRecordDao.xml
@@ -77,7 +77,7 @@
 				#{e.user.id},
 				#{e.readFlag},
 				#{e.readDate}
-			<if test="dbName != 'mssql'">
+			<if test="e.dbName != 'mssql'">
 			FROM dual
 			</if>
 		</foreach>


### PR DESCRIPTION
OaNotifyRecordDao.xml 里面insertAll时使用dbName时有误，运行起来后，添加通知的时候会抛异常，改成e.dbName就OK了