### PR TITLE
don't get cache from request.getAttribute

### DIFF
--- a/src/main/java/com/thinkgem/jeesite/common/security/shiro/cache/JedisCacheManager.java
+++ b/src/main/java/com/thinkgem/jeesite/common/security/shiro/cache/JedisCacheManager.java
@@ -69,16 +69,8 @@ public class JedisCacheManager implements CacheManager {
 			if (key == null){
 				return null;
 			}
-			
-			V v = null;
+						
 			HttpServletRequest request = Servlets.getRequest();
-			if (request != null){
-				v = (V)request.getAttribute(cacheKeyName);
-				if (v != null){
-					return v;
-				}
-			}
-			
 			V value = null;
 			Jedis jedis = null;
 			try {
@@ -89,10 +81,6 @@ public class JedisCacheManager implements CacheManager {
 				logger.error("get {} {} {}", cacheKeyName, key, request != null ? request.getRequestURI() : "", e);
 			} finally {
 				JedisUtils.returnResource(jedis);
-			}
-			
-			if (request != null && value != null){
-				request.setAttribute(cacheKeyName, value);
 			}
 			
 			return value;


### PR DESCRIPTION
when i use redis as cache, I found this bug, I don't think your meas is get cache from request,so I remove the code.

