### PR TITLE
jQuery.data is a low-level method and data should be used instead

### DIFF
--- a/src/main/webapp/static/jqGrid/4.6/plugins/jquery.searchFilter.js
+++ b/src/main/webapp/static/jqGrid/4.6/plugins/jquery.searchFilter.js
@@ -405,7 +405,7 @@ jQuery.fn.searchFilter = function(fields, options) {
                 }
                 if (opts.datepickerFix === true && jQuery.fn.datepicker !== undefined) { // using $.data to associate data with document elements is Not Good
                     row.find(".hasDatepicker").each(function() {
-                        var settings = jQuery.data(this, "datepicker").settings;
+                        var settings = this.data("datepicker").settings;
                         newRow.find("#" + this.id).unbind().removeAttr("id").removeClass("hasDatepicker").datepicker(settings);
                     });
                 }
@@ -462,7 +462,7 @@ jQuery.fn.searchFilter = function(fields, options) {
                 newRow.find("select[name='field']").focus();
                 if (opts.datepickerFix === true && jQuery.fn.datepicker !== undefined) { // using $.data to associate data with document elements is Not Good
                     row.find(".hasDatepicker").each(function() {
-                        var settings = jQuery.data(this, "datepicker").settings;
+                        var settings = this.data("datepicker").settings;
                         newRow.find("#" + this.id).unbind().removeAttr("id").removeClass("hasDatepicker").datepicker(settings);
                     });
                 }


### PR DESCRIPTION
The jQuery doc for [jQuery.data()](https://api.jquery.com/jQuery.data/) says this is a "low-level method" and that you should use .data() instead.