### PR TITLE
fix: StringUtils.toLong 方法在转换过程中精度丢失的问题。

### DIFF
--- a/src/main/java/com/thinkgem/jeesite/common/utils/StringUtils.java
+++ b/src/main/java/com/thinkgem/jeesite/common/utils/StringUtils.java
@@ -252,8 +252,19 @@ public class StringUtils extends org.apache.commons.lang3.StringUtils {
 	/**
 	 * 转换为Long类型
 	 */
-	public static Long toLong(Object val){
-		return toDouble(val).longValue();
+//	public static Long toLong(Object val){
+//		return toDouble(val).longValue();
+//	}
+
+	public static Long toLong(Object val) {
+		if (val == null) {
+			return 0L;
+		}
+		try {
+			return Long.valueOf(trim(val.toString()));
+		} catch (Exception e) {
+			return 0L;
+		}
 	}
 
 	/**

--- a/src/test/java/com/thinkgem/jeesite/common/utils/StringUtilsTest.java
+++ b/src/test/java/com/thinkgem/jeesite/common/utils/StringUtilsTest.java
@@ -1,0 +1,36 @@
+package com.thinkgem.jeesite.common.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class StringUtilsTest {
+
+    @Test
+    public void toLongTest() {
+
+        String s = "778351528171171845";
+
+        Long value = StringUtils.toLong(s);
+        System.out.println(value);//778351528171171845
+
+        Assert.assertEquals(778351528171171845L, value.longValue());
+    }
+
+    @Test
+    public void oldToLongTest() {
+
+        String s = "778351528171171845";
+
+        Long value = this.toLong(s);
+        System.out.println(value);//778351528171171840
+
+        Assert.assertNotEquals(778351528171171845L, value.longValue());
+    }
+
+    //这个是旧的 tolong方法
+    public static Long toLong(Object val) {
+        return StringUtils.toDouble(val).longValue();
+    }
+}


### PR DESCRIPTION
StringUtils.toLong 方法在到long字符串进行转换，会造成精度丢失。 见单元测试 。